### PR TITLE
error.html not showing up in the root directory #43

### DIFF
--- a/_src/error.html
+++ b/_src/error.html
@@ -2,6 +2,7 @@
 layout: page
 title: Error
 sitemap: false
+permalink: /error.html
 ---
 <section class="error bg-white">
   <div class="container">


### PR DESCRIPTION
- set permalink for `error.html` as its defautling to `/error/`
- closes #43