### PR TITLE
Demo form validation #67

### DIFF
--- a/_src/_data/schedule_demo.yml
+++ b/_src/_data/schedule_demo.yml
@@ -42,7 +42,7 @@ check:
   label: I agree to receive emails
   required: required
   name: agree
-  checked: true
+  checked: false
 
 button:
   title: Send Request

--- a/_src/_data/schedule_demo.yml
+++ b/_src/_data/schedule_demo.yml
@@ -42,6 +42,7 @@ check:
   label: I agree to receive emails
   required: required
   name: agree
+  checked: true
 
 button:
   title: Send Request

--- a/_src/_includes/form_inputs.html
+++ b/_src/_includes/form_inputs.html
@@ -9,9 +9,7 @@
     </label>
 
     <!-- Input -->
-    <input type="{{i.type}}" {%- if i.type == email -%}
-      pattern="/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA -Z0-9 -] {0,61} [a-zA-Z0-9])? (?: \. [A-zA-Z0-9] (?: [A-zA-Z0-9 -] { 0,61} [a-zA-Z0-9])?) * $ /"
-      {%- endif -%} 
+    <input type="{{i.type}}"
       {%- if i.name == "aws_id" -%}
         pattern="^\d{12}$"
         minlength="12"

--- a/_src/schedule_demo.html
+++ b/_src/schedule_demo.html
@@ -48,7 +48,7 @@ description: Our goal is to be as helpful as possible.
             </div>
 
             <div class="form-group mb-5">
-              <input type="checkbox" id="{{c.check.name}}" name="{{c.check.name}}"{%- if c.check.checked == true -%} checked{%- endif -%} />
+              <input required type="checkbox" id="{{c.check.name}}" name="{{c.check.name}}"{%- if c.check.checked == true -%} checked{%- endif -%} />
               <label for="{{c.check.name}}">{{c.check.label}}</label>
             </div>
 

--- a/_src/schedule_demo.html
+++ b/_src/schedule_demo.html
@@ -48,7 +48,7 @@ description: Our goal is to be as helpful as possible.
             </div>
 
             <div class="form-group mb-5">
-              <input type="checkbox" id="{{c.check.name}}" name="{{c.check.name}}" />
+              <input type="checkbox" id="{{c.check.name}}" name="{{c.check.name}}"{%- if c.check.checked == true -%} checked{%- endif -%} />
               <label for="{{c.check.name}}">{{c.check.label}}</label>
             </div>
 


### PR DESCRIPTION
- check the checkbox by default
- remove pattern and just rely on browser validation for `email`
- closes #67 