### PR TITLE
Broken footer in 404 #59

### DIFF
--- a/_src/404.html
+++ b/_src/404.html
@@ -3,22 +3,9 @@ permalink: /404.html
 layout: page
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
 <section class="bg-white error">
-<div class="container">
-  <h1>404</h1>
+<div class="container shame__container--special">
+  <h1 class="shame__h1--special">404</h1>
   <p><strong>Page not found :(</strong></p>
   <p>The requested page could not be found.</p>
 </div>

--- a/_src/assets/css/custom.scss
+++ b/_src/assets/css/custom.scss
@@ -68,3 +68,16 @@
 .opacity-9 {
   opacity:0.9!important;
 }
+
+.shame__container--special {
+  margin: 10px auto;
+  max-width: 600px;
+  text-align: center;
+}
+
+.shame__h1--special {
+  margin: 30px 0;
+  font-size: 4em;
+  line-height: 1;
+  letter-spacing: -1px;
+}


### PR DESCRIPTION
- move styles into CSS
- no longer use `container` class which is also used in the footer
- closes #59 